### PR TITLE
The Rdio tab is sometimes just called "Rdio"

### DIFF
--- a/js/findRdioTab.js
+++ b/js/findRdioTab.js
@@ -7,7 +7,7 @@ function findRdioTab(){
     var window = app.windows[i];
     var possibleRdioTabs = window.tabs.whose({
       url: { _contains: "rdio.com" },
-      title: { _endsWith : "– Rdio" }
+      title: { _endsWith : "Rdio" }
     })
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);

--- a/plugin/applescripts/rdio-list-playlists.applescript.js
+++ b/plugin/applescripts/rdio-list-playlists.applescript.js
@@ -9,7 +9,7 @@ function findRdioTab(){
     var window = app.windows[i];
     var possibleRdioTabs = window.tabs.whose({
       url: { _contains: "rdio.com" },
-      title: { _endsWith : "– Rdio" }
+      title: { _endsWith : "Rdio" }
     })
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);

--- a/plugin/applescripts/rdio-next.applescript.js
+++ b/plugin/applescripts/rdio-next.applescript.js
@@ -9,7 +9,7 @@ function findRdioTab(){
     var window = app.windows[i];
     var possibleRdioTabs = window.tabs.whose({
       url: { _contains: "rdio.com" },
-      title: { _endsWith : "– Rdio" }
+      title: { _endsWith : "Rdio" }
     })
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);

--- a/plugin/applescripts/rdio-play-pause.applescript.js
+++ b/plugin/applescripts/rdio-play-pause.applescript.js
@@ -9,7 +9,7 @@ function findRdioTab(){
     var window = app.windows[i];
     var possibleRdioTabs = window.tabs.whose({
       url: { _contains: "rdio.com" },
-      title: { _endsWith : "– Rdio" }
+      title: { _endsWith : "Rdio" }
     })
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);

--- a/plugin/applescripts/rdio-play-specific-playlist.applescript.js
+++ b/plugin/applescripts/rdio-play-specific-playlist.applescript.js
@@ -9,7 +9,7 @@ function findRdioTab(){
     var window = app.windows[i];
     var possibleRdioTabs = window.tabs.whose({
       url: { _contains: "rdio.com" },
-      title: { _endsWith : "– Rdio" }
+      title: { _endsWith : "Rdio" }
     })
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);


### PR DESCRIPTION
When on the homepage, the tab is called "Rdio" (which still matches "endsWith: Rdio"). The tab title only ends in "- Rdio" when viewing an item, like an album.