### PR TITLE
Consolidate JS into one file

### DIFF
--- a/js/all.js
+++ b/js/all.js
@@ -1,0 +1,36 @@
+var VimRdio = VimRdio || {};
+
+VimRdio.getPlaylistNames = function(){
+  return _.map($("a.playlist"), function(a) { return $(a).prop("title"); })
+};
+
+VimRdio.next = function(){
+  // Also: R.player.next()
+  $("button.next").click();
+};
+
+// Start playing the first song of the playlist whose page we're on.
+VimRdio.playCurrentPlaylist = function(){
+  $(".PlayButton:visible:first").click();
+};
+
+VimRdio.playFavorites = function(){
+  setTimeout(VimRdio.playCurrentPlaylist, 3000);
+
+  var $linkToFavoritesStation = $(".user_nav .station_row");
+  $linkToFavoritesStation.click();
+};
+
+VimRdio.playPause = function(){
+  // Also: R.player.playPause()
+  $(".play_pause").click();
+};
+
+VimRdio.selectAndPlayPlaylist = function(playlistName){
+  // Wait 3 seconds before hitting play, which should be enough time for the
+  // new playlist to load. Make the timeout longer if it's kicking in too soon
+  // (for example, if you have a slow connection).
+  setTimeout(VimRdio.playCurrentPlaylist, 3000);
+
+  $("a.playlist[title='" + playlistName + "']").click()
+}

--- a/js/findRdioTab.js
+++ b/js/findRdioTab.js
@@ -1,4 +1,6 @@
-function findRdioTab(){
+var VimRdio = VimRdio || {};
+
+VimRdio.findRdioTab = function(){
   var app = Application("Google Chrome");
   var rdioTab = undefined;
 

--- a/js/getPlaylistNames.js
+++ b/js/getPlaylistNames.js
@@ -1,3 +1,0 @@
-function getPlaylistNames(){
-  return _.map($('a.playlist'), function(a) { return $(a).prop('title'); })
-}

--- a/js/next.js
+++ b/js/next.js
@@ -1,4 +1,0 @@
-function next(){
-  // Also: R.player.next()
-  $('button.next').click();
-}

--- a/js/playCurrentPlaylist.js
+++ b/js/playCurrentPlaylist.js
@@ -1,4 +1,0 @@
-// Start playing the first song of the playlist whose page we're on.
-function playCurrentPlaylist(){
-  $(".PlayButton:visible:first").click();
-}

--- a/js/playFavorites.js
+++ b/js/playFavorites.js
@@ -1,6 +1,0 @@
-function playFavorites(){
-  setTimeout(playCurrentPlaylist, 3000);
-
-  var $linkToFavoritesStation = $(".user_nav .station_row");
-  $linkToFavoritesStation.click();
-}

--- a/js/playPause.js
+++ b/js/playPause.js
@@ -1,4 +1,0 @@
-function playPause(){
-  // Also: R.player.playPause()
-  $('.play_pause').click();
-}

--- a/js/selectAndPlayPlaylist.js
+++ b/js/selectAndPlayPlaylist.js
@@ -1,8 +1,0 @@
-function selectAndPlayPlaylist(playlistName){
-  // Wait 3 seconds before hitting play, which should be enough time for the
-  // new playlist to load. Make the timeout longer if it's kicking in too soon
-  // (for example, if you have a slow connection).
-  setTimeout(playCurrentPlaylist, 3000);
-
-  $("a.playlist[title='" + playlistName + "']").click()
-}

--- a/plugin/applescripts/rdio-favorites.applescript.js
+++ b/plugin/applescripts/rdio-favorites.applescript.js
@@ -1,6 +1,8 @@
 // vim: filetype=javascript
 
-function findRdioTab(){
+var VimRdio = VimRdio || {};
+
+VimRdio.findRdioTab = function(){
   var app = Application("Google Chrome");
   var rdioTab = undefined;
 
@@ -20,14 +22,11 @@ function findRdioTab(){
 }
 
 
-var playCurrentPlaylist = "function playCurrentPlaylist(){   $(\".PlayButton:visible:first\").click(); }";
-var playFavorites = "function playFavorites(){   setTimeout(playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); }";
-var defineFunctions = playCurrentPlaylist + playFavorites;
-
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv){
-  var rdioTab = findRdioTab();
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: "playFavorites()"});
+  var rdioTab = VimRdio.findRdioTab();
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.execute({javascript: defineFunctions})
+  rdioTab.execute({javascript: "VimRdio.playFavorites()"});
 }

--- a/plugin/applescripts/rdio-list-playlists.applescript.js
+++ b/plugin/applescripts/rdio-list-playlists.applescript.js
@@ -1,6 +1,8 @@
 // vim: filetype=javascript
 
-function findRdioTab(){
+var VimRdio = VimRdio || {};
+
+VimRdio.findRdioTab = function(){
   var app = Application("Google Chrome");
   var rdioTab = undefined;
 
@@ -23,11 +25,12 @@ function findRdioTab(){
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv) {
-  var rdioTab = findRdioTab();
+  var rdioTab = VimRdio.findRdioTab();
+
   if( rdioTab !== undefined ){
-    var defineFunctions = "function getPlaylistNames(){   return _.map($('a.playlist'), function(a) { return $(a).prop('title'); }) }";
-    rdioTab.execute({javascript: defineFunctions});
-    var result = rdioTab.execute({javascript: 'getPlaylistNames()'})
+    var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+    rdioTab.execute({javascript: defineFunctions})
+    var result = rdioTab.execute({javascript: "VimRdio.getPlaylistNames()"})
 
     // The return value gets printed to STDOUT.
     return result.join("\n");

--- a/plugin/applescripts/rdio-next.applescript.js
+++ b/plugin/applescripts/rdio-next.applescript.js
@@ -1,6 +1,8 @@
 // vim: filetype=javascript
 
-function findRdioTab(){
+var VimRdio = VimRdio || {};
+
+VimRdio.findRdioTab = function(){
   var app = Application("Google Chrome");
   var rdioTab = undefined;
 
@@ -21,8 +23,8 @@ function findRdioTab(){
 
 
 function run(argv) {
-  var rdioTab = findRdioTab();
-  var defineNext = "function next(){   $('button.next').click(); }";
-  rdioTab.execute({javascript: defineNext});
-  rdioTab.execute({javascript: 'next()'});
+  var rdioTab = VimRdio.findRdioTab();
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.execute({javascript: defineFunctions});
+  rdioTab.execute({javascript: "VimRdio.next()"});
 }

--- a/plugin/applescripts/rdio-play-pause.applescript.js
+++ b/plugin/applescripts/rdio-play-pause.applescript.js
@@ -1,6 +1,8 @@
 // vim: filetype=javascript
 
-function findRdioTab(){
+var VimRdio = VimRdio || {};
+
+VimRdio.findRdioTab = function(){
   var app = Application("Google Chrome");
   var rdioTab = undefined;
 
@@ -21,8 +23,8 @@ function findRdioTab(){
 
 
 function run(argv) {
-  var rdioTab = findRdioTab();
-  var definePlayPause = "function playPause(){   $('.play_pause').click(); }";
-  rdioTab.execute({javascript: definePlayPause});
-  rdioTab.execute({javascript: 'playPause()'})
+  var rdioTab = VimRdio.findRdioTab();
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.execute({javascript: defineFunctions});
+  rdioTab.execute({javascript: "VimRdio.playPause()"});
 }

--- a/plugin/applescripts/rdio-play-specific-playlist.applescript.js
+++ b/plugin/applescripts/rdio-play-specific-playlist.applescript.js
@@ -1,6 +1,8 @@
 // vim: filetype=javascript
 
-function findRdioTab(){
+var VimRdio = VimRdio || {};
+
+VimRdio.findRdioTab = function(){
   var app = Application("Google Chrome");
   var rdioTab = undefined;
 
@@ -20,15 +22,14 @@ function findRdioTab(){
 }
 
 
-var playCurrentPlaylist = "function playCurrentPlaylist(){   $(\".PlayButton:visible:first\").click(); }";
-var selectAndPlayPlaylist = "function selectAndPlayPlaylist(playlistName){   setTimeout(playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
-var defineFunctions = playCurrentPlaylist + selectAndPlayPlaylist;
-
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv){
-  var rdioTab = findRdioTab();
+  var rdioTab = VimRdio.findRdioTab();
   var playlistName = argv[0];
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
   rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: 'selectAndPlayPlaylist("' + playlistName + '")'})
+  rdioTab.execute({
+    javascript: 'VimRdio.selectAndPlayPlaylist("' + playlistName + '")'
+  });
 }

--- a/source/rdio-favorites.applescript.js.erb
+++ b/source/rdio-favorites.applescript.js.erb
@@ -2,14 +2,11 @@
 
 <%= File.read("./js/findRdioTab.js") %>
 
-var playCurrentPlaylist = <%= minify_javascript("playCurrentPlaylist.js") %>;
-var playFavorites = <%= minify_javascript("playFavorites.js") %>;
-var defineFunctions = playCurrentPlaylist + playFavorites;
-
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv){
-  var rdioTab = findRdioTab();
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: "playFavorites()"});
+  var rdioTab = VimRdio.findRdioTab();
+  var defineFunctions = <%= minify_javascript("all.js") %>;
+  rdioTab.execute({javascript: defineFunctions})
+  rdioTab.execute({javascript: "VimRdio.playFavorites()"});
 }

--- a/source/rdio-list-playlists.applescript.js.erb
+++ b/source/rdio-list-playlists.applescript.js.erb
@@ -5,11 +5,12 @@
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv) {
-  var rdioTab = findRdioTab();
+  var rdioTab = VimRdio.findRdioTab();
+
   if( rdioTab !== undefined ){
-    var defineFunctions = <%= minify_javascript("getPlaylistNames.js") %>;
-    rdioTab.execute({javascript: defineFunctions});
-    var result = rdioTab.execute({javascript: 'getPlaylistNames()'})
+    var defineFunctions = <%= minify_javascript("all.js") %>;
+    rdioTab.execute({javascript: defineFunctions})
+    var result = rdioTab.execute({javascript: "VimRdio.getPlaylistNames()"})
 
     // The return value gets printed to STDOUT.
     return result.join("\n");

--- a/source/rdio-next.applescript.js.erb
+++ b/source/rdio-next.applescript.js.erb
@@ -3,8 +3,8 @@
 <%= File.read("./js/findRdioTab.js") %>
 
 function run(argv) {
-  var rdioTab = findRdioTab();
-  var defineNext = <%= minify_javascript("next.js") %>;
-  rdioTab.execute({javascript: defineNext});
-  rdioTab.execute({javascript: 'next()'});
+  var rdioTab = VimRdio.findRdioTab();
+  var defineFunctions = <%= minify_javascript("all.js") %>;
+  rdioTab.execute({javascript: defineFunctions});
+  rdioTab.execute({javascript: "VimRdio.next()"});
 }

--- a/source/rdio-play-pause.applescript.js.erb
+++ b/source/rdio-play-pause.applescript.js.erb
@@ -3,8 +3,8 @@
 <%= File.read("./js/findRdioTab.js") %>
 
 function run(argv) {
-  var rdioTab = findRdioTab();
-  var definePlayPause = <%= minify_javascript("playPause.js") %>;
-  rdioTab.execute({javascript: definePlayPause});
-  rdioTab.execute({javascript: 'playPause()'})
+  var rdioTab = VimRdio.findRdioTab();
+  var defineFunctions = <%= minify_javascript("all.js") %>;
+  rdioTab.execute({javascript: defineFunctions});
+  rdioTab.execute({javascript: "VimRdio.playPause()"});
 }

--- a/source/rdio-play-specific-playlist.applescript.js.erb
+++ b/source/rdio-play-specific-playlist.applescript.js.erb
@@ -2,15 +2,14 @@
 
 <%= File.read("./js/findRdioTab.js") %>
 
-var playCurrentPlaylist = <%= minify_javascript("playCurrentPlaylist.js") %>;
-var selectAndPlayPlaylist = <%= minify_javascript("selectAndPlayPlaylist.js") %>;
-var defineFunctions = playCurrentPlaylist + selectAndPlayPlaylist;
-
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv){
-  var rdioTab = findRdioTab();
+  var rdioTab = VimRdio.findRdioTab();
   var playlistName = argv[0];
+  var defineFunctions = <%= minify_javascript("all.js") %>;
   rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: 'selectAndPlayPlaylist("' + playlistName + '")'})
+  rdioTab.execute({
+    javascript: 'VimRdio.selectAndPlayPlaylist("' + playlistName + '")'
+  });
 }


### PR DESCRIPTION
This means it's easier to reason about the Javascript, since it's all just right there. I kept `findRdioTab.js` separate, since it's always used alone and there's no reason to load everything else just to get it.

For cleanliness reasons and not much else, I introduced a `VimRdio` namespace.