### PR TITLE
Ensure rendered files are re-rendered each time

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,13 +15,16 @@ FileUtils.mkdir_p(OUTPUT)
 
 desc "Render all .something.#{EXTENSION} files into .something files"
 task :render_erb do
-  scpt_in_file_paths = Dir.glob("source/*.#{EXTENSION}")
-  scpt_in_file_paths.each do |scpt_in_file_path|
-    without_extension = scpt_in_file_path.sub(/\.#{EXTENSION}$/, "")
-    output_file_path = File.basename(without_extension)
-    contents = File.read(scpt_in_file_path)
-    result = ERB.new(contents).result(binding)
-    File.new(OUTPUT + output_file_path, "w").write(result)
+  paths = Dir.glob("source/*.#{EXTENSION}")
+  paths.each do |path|
+    without_extension = path.sub(/\.#{EXTENSION}$/, "")
+    output_basename = File.basename(without_extension)
+    full_output_path = OUTPUT + output_basename
+
+    rendered = ERB.new(File.read(path)).result(binding)
+
+    FileUtils.rm_f(full_output_path)
+    File.new(full_output_path, "w").write(rendered)
   end
 end
 


### PR DESCRIPTION
`File.new(path, "w")` didn't always overwrite files. Removing the file and writing to it does, which is what we want.