### PR TITLE
Add support for Safari

### DIFF
--- a/js/findRdioTab.js
+++ b/js/findRdioTab.js
@@ -1,20 +1,47 @@
 var VimRdio = VimRdio || {};
 
-VimRdio.findRdioTab = function(){
-  var app = Application("Google Chrome");
-  var rdioTab = undefined;
+// Detect if an application with the given name is running.
+// This is necessary because calling `Application(name)` causes that application
+// to open. This way we can check if something is running without opening it.
+VimRdio._applicationIsRunning = function(applicationName){
+  var systemEvents = Application("System Events");
 
-  // Find the tab that has Rdio in it
-  for(var i = 0; i < app.windows().length; i++){
-    var window = app.windows[i];
-    var possibleRdioTabs = window.tabs.whose({
-      url: { _contains: "rdio.com" },
-      title: { _endsWith : "Rdio" }
-    })
+  var applicationsWithName = systemEvents.applicationProcesses.whose({name: applicationName});
+  return applicationsWithName.length > 0;
+}
+
+// Given the name of an application (like "Google Chrome"), and the name of the
+// tab property that corresponds to the tab's title, search that application for
+// the tab that has Rdio playing in it.
+// We need tabTitleProperty because Chrome has `tab.title`, while Safari calls
+// it `tab.name`.
+VimRdio._findRdioTab = function(applicationName, tabTitleProperty){
+  var application = Application(applicationName);
+  var rdioTab = undefined;
+  var criteria = {};
+  criteria.url = { _contains: "rdio.com" };
+  criteria[tabTitleProperty] = { _endsWith : "Rdio" };
+
+  for(var i = 0; i < application.windows().length; i++){
+    var window = application.windows[i];
+    var possibleRdioTabs = window.tabs.whose(criteria);
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);
       break;
     }
   }
-  return rdioTab;
+  if(rdioTab){
+    return new VimRdio.RdioTab(application, rdioTab);
+  } else {
+    return undefined;
+  }
+}
+
+// Find a tab that has Rdio in it, in either Google Chrome or Safari.
+VimRdio.findRdioTab = function(){
+  if(VimRdio._applicationIsRunning("Google Chrome")){
+    return VimRdio._findRdioTab("Google Chrome", "title")
+  } else if(VimRdio._applicationIsRunning("Safari")){
+    return VimRdio._findRdioTab("Safari", "name")
+  }
 }

--- a/js/rdioTab.js
+++ b/js/rdioTab.js
@@ -1,0 +1,18 @@
+// An object that wraps the Rdio browser tab returned by the Javascript bridge.
+//
+// It's an intermediate layer so we can use the same interface to send
+// Javascript to a Safari or Google Chrome tab, both of which have slightly
+// differnt APIs.
+
+VimRdio.RdioTab = function(application, tab){
+  this.application = application;
+  this.tab = tab;
+};
+
+VimRdio.RdioTab.prototype.executeJavascript = function(javascript){
+  if(this.application.name() === "Google Chrome"){
+    this.tab.execute({javascript: javascript});
+  } else if(this.application.name() === "Safari"){
+    this.application.doJavaScript(javascript, {in: this.tab});
+  }
+};

--- a/plugin/applescripts/rdio-favorites.applescript.js
+++ b/plugin/applescripts/rdio-favorites.applescript.js
@@ -2,31 +2,77 @@
 
 var VimRdio = VimRdio || {};
 
-VimRdio.findRdioTab = function(){
-  var app = Application("Google Chrome");
-  var rdioTab = undefined;
+// Detect if an application with the given name is running.
+// This is necessary because calling `Application(name)` causes that application
+// to open. This way we can check if something is running without opening it.
+VimRdio._applicationIsRunning = function(applicationName){
+  var systemEvents = Application("System Events");
 
-  // Find the tab that has Rdio in it
-  for(var i = 0; i < app.windows().length; i++){
-    var window = app.windows[i];
-    var possibleRdioTabs = window.tabs.whose({
-      url: { _contains: "rdio.com" },
-      title: { _endsWith : "Rdio" }
-    })
+  var applicationsWithName = systemEvents.applicationProcesses.whose({name: applicationName});
+  return applicationsWithName.length > 0;
+}
+
+// Given the name of an application (like "Google Chrome"), and the name of the
+// tab property that corresponds to the tab's title, search that application for
+// the tab that has Rdio playing in it.
+// We need tabTitleProperty because Chrome has `tab.title`, while Safari calls
+// it `tab.name`.
+VimRdio._findRdioTab = function(applicationName, tabTitleProperty){
+  var application = Application(applicationName);
+  var rdioTab = undefined;
+  var criteria = {};
+  criteria.url = { _contains: "rdio.com" };
+  criteria[tabTitleProperty] = { _endsWith : "Rdio" };
+
+  for(var i = 0; i < application.windows().length; i++){
+    var window = application.windows[i];
+    var possibleRdioTabs = window.tabs.whose(criteria);
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);
       break;
     }
   }
-  return rdioTab;
+  if(rdioTab){
+    return new VimRdio.RdioTab(application, rdioTab);
+  } else {
+    return undefined;
+  }
 }
+
+// Find a tab that has Rdio in it, in either Google Chrome or Safari.
+VimRdio.findRdioTab = function(){
+  if(VimRdio._applicationIsRunning("Google Chrome")){
+    return VimRdio._findRdioTab("Google Chrome", "title")
+  } else if(VimRdio._applicationIsRunning("Safari")){
+    return VimRdio._findRdioTab("Safari", "name")
+  }
+}
+
+// An object that wraps the Rdio browser tab returned by the Javascript bridge.
+//
+// It's an intermediate layer so we can use the same interface to send
+// Javascript to a Safari or Google Chrome tab, both of which have slightly
+// differnt APIs.
+
+VimRdio.RdioTab = function(application, tab){
+  this.application = application;
+  this.tab = tab;
+};
+
+VimRdio.RdioTab.prototype.executeJavascript = function(javascript){
+  if(this.application.name() === "Google Chrome"){
+    this.tab.execute({javascript: javascript});
+  } else if(this.application.name() === "Safari"){
+    this.application.doJavaScript(javascript, {in: this.tab});
+  }
+};
 
 
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv){
   var rdioTab = VimRdio.findRdioTab();
-  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
-  rdioTab.execute({javascript: defineFunctions})
-  rdioTab.execute({javascript: "VimRdio.playFavorites()"});
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   R.player.next(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   R.player.playPause() };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.executeJavascript(defineFunctions)
+  rdioTab.executeJavascript("VimRdio.playFavorites()");
 }

--- a/plugin/applescripts/rdio-list-playlists.applescript.js
+++ b/plugin/applescripts/rdio-list-playlists.applescript.js
@@ -2,24 +2,70 @@
 
 var VimRdio = VimRdio || {};
 
-VimRdio.findRdioTab = function(){
-  var app = Application("Google Chrome");
-  var rdioTab = undefined;
+// Detect if an application with the given name is running.
+// This is necessary because calling `Application(name)` causes that application
+// to open. This way we can check if something is running without opening it.
+VimRdio._applicationIsRunning = function(applicationName){
+  var systemEvents = Application("System Events");
 
-  // Find the tab that has Rdio in it
-  for(var i = 0; i < app.windows().length; i++){
-    var window = app.windows[i];
-    var possibleRdioTabs = window.tabs.whose({
-      url: { _contains: "rdio.com" },
-      title: { _endsWith : "Rdio" }
-    })
+  var applicationsWithName = systemEvents.applicationProcesses.whose({name: applicationName});
+  return applicationsWithName.length > 0;
+}
+
+// Given the name of an application (like "Google Chrome"), and the name of the
+// tab property that corresponds to the tab's title, search that application for
+// the tab that has Rdio playing in it.
+// We need tabTitleProperty because Chrome has `tab.title`, while Safari calls
+// it `tab.name`.
+VimRdio._findRdioTab = function(applicationName, tabTitleProperty){
+  var application = Application(applicationName);
+  var rdioTab = undefined;
+  var criteria = {};
+  criteria.url = { _contains: "rdio.com" };
+  criteria[tabTitleProperty] = { _endsWith : "Rdio" };
+
+  for(var i = 0; i < application.windows().length; i++){
+    var window = application.windows[i];
+    var possibleRdioTabs = window.tabs.whose(criteria);
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);
       break;
     }
   }
-  return rdioTab;
+  if(rdioTab){
+    return new VimRdio.RdioTab(application, rdioTab);
+  } else {
+    return undefined;
+  }
 }
+
+// Find a tab that has Rdio in it, in either Google Chrome or Safari.
+VimRdio.findRdioTab = function(){
+  if(VimRdio._applicationIsRunning("Google Chrome")){
+    return VimRdio._findRdioTab("Google Chrome", "title")
+  } else if(VimRdio._applicationIsRunning("Safari")){
+    return VimRdio._findRdioTab("Safari", "name")
+  }
+}
+
+// An object that wraps the Rdio browser tab returned by the Javascript bridge.
+//
+// It's an intermediate layer so we can use the same interface to send
+// Javascript to a Safari or Google Chrome tab, both of which have slightly
+// differnt APIs.
+
+VimRdio.RdioTab = function(application, tab){
+  this.application = application;
+  this.tab = tab;
+};
+
+VimRdio.RdioTab.prototype.executeJavascript = function(javascript){
+  if(this.application.name() === "Google Chrome"){
+    this.tab.execute({javascript: javascript});
+  } else if(this.application.name() === "Safari"){
+    this.application.doJavaScript(javascript, {in: this.tab});
+  }
+};
 
 
 // The "run" function is automatically run when the file is run, like "main" in
@@ -28,9 +74,9 @@ function run(argv) {
   var rdioTab = VimRdio.findRdioTab();
 
   if( rdioTab !== undefined ){
-    var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
-    rdioTab.execute({javascript: defineFunctions})
-    var result = rdioTab.execute({javascript: "VimRdio.getPlaylistNames()"})
+    var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   R.player.next(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   R.player.playPause() };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+    rdioTab.executeJavascript(defineFunctions);
+    var result = rdioTab.executeJavascript("VimRdio.getPlaylistNames()");
 
     // The return value gets printed to STDOUT.
     return result.join("\n");

--- a/plugin/applescripts/rdio-next.applescript.js
+++ b/plugin/applescripts/rdio-next.applescript.js
@@ -2,29 +2,75 @@
 
 var VimRdio = VimRdio || {};
 
-VimRdio.findRdioTab = function(){
-  var app = Application("Google Chrome");
-  var rdioTab = undefined;
+// Detect if an application with the given name is running.
+// This is necessary because calling `Application(name)` causes that application
+// to open. This way we can check if something is running without opening it.
+VimRdio._applicationIsRunning = function(applicationName){
+  var systemEvents = Application("System Events");
 
-  // Find the tab that has Rdio in it
-  for(var i = 0; i < app.windows().length; i++){
-    var window = app.windows[i];
-    var possibleRdioTabs = window.tabs.whose({
-      url: { _contains: "rdio.com" },
-      title: { _endsWith : "Rdio" }
-    })
+  var applicationsWithName = systemEvents.applicationProcesses.whose({name: applicationName});
+  return applicationsWithName.length > 0;
+}
+
+// Given the name of an application (like "Google Chrome"), and the name of the
+// tab property that corresponds to the tab's title, search that application for
+// the tab that has Rdio playing in it.
+// We need tabTitleProperty because Chrome has `tab.title`, while Safari calls
+// it `tab.name`.
+VimRdio._findRdioTab = function(applicationName, tabTitleProperty){
+  var application = Application(applicationName);
+  var rdioTab = undefined;
+  var criteria = {};
+  criteria.url = { _contains: "rdio.com" };
+  criteria[tabTitleProperty] = { _endsWith : "Rdio" };
+
+  for(var i = 0; i < application.windows().length; i++){
+    var window = application.windows[i];
+    var possibleRdioTabs = window.tabs.whose(criteria);
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);
       break;
     }
   }
-  return rdioTab;
+  if(rdioTab){
+    return new VimRdio.RdioTab(application, rdioTab);
+  } else {
+    return undefined;
+  }
 }
+
+// Find a tab that has Rdio in it, in either Google Chrome or Safari.
+VimRdio.findRdioTab = function(){
+  if(VimRdio._applicationIsRunning("Google Chrome")){
+    return VimRdio._findRdioTab("Google Chrome", "title")
+  } else if(VimRdio._applicationIsRunning("Safari")){
+    return VimRdio._findRdioTab("Safari", "name")
+  }
+}
+
+// An object that wraps the Rdio browser tab returned by the Javascript bridge.
+//
+// It's an intermediate layer so we can use the same interface to send
+// Javascript to a Safari or Google Chrome tab, both of which have slightly
+// differnt APIs.
+
+VimRdio.RdioTab = function(application, tab){
+  this.application = application;
+  this.tab = tab;
+};
+
+VimRdio.RdioTab.prototype.executeJavascript = function(javascript){
+  if(this.application.name() === "Google Chrome"){
+    this.tab.execute({javascript: javascript});
+  } else if(this.application.name() === "Safari"){
+    this.application.doJavaScript(javascript, {in: this.tab});
+  }
+};
 
 
 function run(argv) {
   var rdioTab = VimRdio.findRdioTab();
-  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: "VimRdio.next()"});
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   R.player.next(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   R.player.playPause() };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.executeJavascript(defineFunctions)
+  rdioTab.executeJavascript("VimRdio.next()");
 }

--- a/plugin/applescripts/rdio-play-pause.applescript.js
+++ b/plugin/applescripts/rdio-play-pause.applescript.js
@@ -2,29 +2,75 @@
 
 var VimRdio = VimRdio || {};
 
-VimRdio.findRdioTab = function(){
-  var app = Application("Google Chrome");
-  var rdioTab = undefined;
+// Detect if an application with the given name is running.
+// This is necessary because calling `Application(name)` causes that application
+// to open. This way we can check if something is running without opening it.
+VimRdio._applicationIsRunning = function(applicationName){
+  var systemEvents = Application("System Events");
 
-  // Find the tab that has Rdio in it
-  for(var i = 0; i < app.windows().length; i++){
-    var window = app.windows[i];
-    var possibleRdioTabs = window.tabs.whose({
-      url: { _contains: "rdio.com" },
-      title: { _endsWith : "Rdio" }
-    })
+  var applicationsWithName = systemEvents.applicationProcesses.whose({name: applicationName});
+  return applicationsWithName.length > 0;
+}
+
+// Given the name of an application (like "Google Chrome"), and the name of the
+// tab property that corresponds to the tab's title, search that application for
+// the tab that has Rdio playing in it.
+// We need tabTitleProperty because Chrome has `tab.title`, while Safari calls
+// it `tab.name`.
+VimRdio._findRdioTab = function(applicationName, tabTitleProperty){
+  var application = Application(applicationName);
+  var rdioTab = undefined;
+  var criteria = {};
+  criteria.url = { _contains: "rdio.com" };
+  criteria[tabTitleProperty] = { _endsWith : "Rdio" };
+
+  for(var i = 0; i < application.windows().length; i++){
+    var window = application.windows[i];
+    var possibleRdioTabs = window.tabs.whose(criteria);
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);
       break;
     }
   }
-  return rdioTab;
+  if(rdioTab){
+    return new VimRdio.RdioTab(application, rdioTab);
+  } else {
+    return undefined;
+  }
 }
+
+// Find a tab that has Rdio in it, in either Google Chrome or Safari.
+VimRdio.findRdioTab = function(){
+  if(VimRdio._applicationIsRunning("Google Chrome")){
+    return VimRdio._findRdioTab("Google Chrome", "title")
+  } else if(VimRdio._applicationIsRunning("Safari")){
+    return VimRdio._findRdioTab("Safari", "name")
+  }
+}
+
+// An object that wraps the Rdio browser tab returned by the Javascript bridge.
+//
+// It's an intermediate layer so we can use the same interface to send
+// Javascript to a Safari or Google Chrome tab, both of which have slightly
+// differnt APIs.
+
+VimRdio.RdioTab = function(application, tab){
+  this.application = application;
+  this.tab = tab;
+};
+
+VimRdio.RdioTab.prototype.executeJavascript = function(javascript){
+  if(this.application.name() === "Google Chrome"){
+    this.tab.execute({javascript: javascript});
+  } else if(this.application.name() === "Safari"){
+    this.application.doJavaScript(javascript, {in: this.tab});
+  }
+};
 
 
 function run(argv) {
   var rdioTab = VimRdio.findRdioTab();
-  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: "VimRdio.playPause()"});
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   R.player.next(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   R.player.playPause() };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.executeJavascript(defineFunctions);
+  rdioTab.executeJavascript("VimRdio.playPause()");
 }

--- a/plugin/applescripts/rdio-play-specific-playlist.applescript.js
+++ b/plugin/applescripts/rdio-play-specific-playlist.applescript.js
@@ -2,24 +2,70 @@
 
 var VimRdio = VimRdio || {};
 
-VimRdio.findRdioTab = function(){
-  var app = Application("Google Chrome");
-  var rdioTab = undefined;
+// Detect if an application with the given name is running.
+// This is necessary because calling `Application(name)` causes that application
+// to open. This way we can check if something is running without opening it.
+VimRdio._applicationIsRunning = function(applicationName){
+  var systemEvents = Application("System Events");
 
-  // Find the tab that has Rdio in it
-  for(var i = 0; i < app.windows().length; i++){
-    var window = app.windows[i];
-    var possibleRdioTabs = window.tabs.whose({
-      url: { _contains: "rdio.com" },
-      title: { _endsWith : "Rdio" }
-    })
+  var applicationsWithName = systemEvents.applicationProcesses.whose({name: applicationName});
+  return applicationsWithName.length > 0;
+}
+
+// Given the name of an application (like "Google Chrome"), and the name of the
+// tab property that corresponds to the tab's title, search that application for
+// the tab that has Rdio playing in it.
+// We need tabTitleProperty because Chrome has `tab.title`, while Safari calls
+// it `tab.name`.
+VimRdio._findRdioTab = function(applicationName, tabTitleProperty){
+  var application = Application(applicationName);
+  var rdioTab = undefined;
+  var criteria = {};
+  criteria.url = { _contains: "rdio.com" };
+  criteria[tabTitleProperty] = { _endsWith : "Rdio" };
+
+  for(var i = 0; i < application.windows().length; i++){
+    var window = application.windows[i];
+    var possibleRdioTabs = window.tabs.whose(criteria);
     if( possibleRdioTabs.length > 0 ){
       rdioTab = possibleRdioTabs.at(0);
       break;
     }
   }
-  return rdioTab;
+  if(rdioTab){
+    return new VimRdio.RdioTab(application, rdioTab);
+  } else {
+    return undefined;
+  }
 }
+
+// Find a tab that has Rdio in it, in either Google Chrome or Safari.
+VimRdio.findRdioTab = function(){
+  if(VimRdio._applicationIsRunning("Google Chrome")){
+    return VimRdio._findRdioTab("Google Chrome", "title")
+  } else if(VimRdio._applicationIsRunning("Safari")){
+    return VimRdio._findRdioTab("Safari", "name")
+  }
+}
+
+// An object that wraps the Rdio browser tab returned by the Javascript bridge.
+//
+// It's an intermediate layer so we can use the same interface to send
+// Javascript to a Safari or Google Chrome tab, both of which have slightly
+// differnt APIs.
+
+VimRdio.RdioTab = function(application, tab){
+  this.application = application;
+  this.tab = tab;
+};
+
+VimRdio.RdioTab.prototype.executeJavascript = function(javascript){
+  if(this.application.name() === "Google Chrome"){
+    this.tab.execute({javascript: javascript});
+  } else if(this.application.name() === "Safari"){
+    this.application.doJavaScript(javascript, {in: this.tab});
+  }
+};
 
 
 // The "run" function is automatically run when the file is run, like "main" in
@@ -27,9 +73,9 @@ VimRdio.findRdioTab = function(){
 function run(argv){
   var rdioTab = VimRdio.findRdioTab();
   var playlistName = argv[0];
-  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   $(\"button.next\").click(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   $(\".play_pause\").click(); };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({
-    javascript: 'VimRdio.selectAndPlayPlaylist("' + playlistName + '")'
-  });
+  var defineFunctions = "var VimRdio = VimRdio || {};  VimRdio.getPlaylistNames = function(){   return _.map($(\"a.playlist\"), function(a) { return $(a).prop(\"title\"); }) };  VimRdio.next = function(){   R.player.next(); };  VimRdio.playCurrentPlaylist = function(){   $(\".PlayButton:visible:first\").click(); };  VimRdio.playFavorites = function(){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    var $linkToFavoritesStation = $(\".user_nav .station_row\");   $linkToFavoritesStation.click(); };  VimRdio.playPause = function(){   R.player.playPause() };  VimRdio.selectAndPlayPlaylist = function(playlistName){   setTimeout(VimRdio.playCurrentPlaylist, 3000);    $(\"a.playlist[title='\" + playlistName + \"']\").click() }";
+  rdioTab.executeJavascript(defineFunctions);
+  rdioTab.executeJavascript(
+    'VimRdio.selectAndPlayPlaylist("' + playlistName + '")'
+  );
 }

--- a/source/rdio-favorites.applescript.js.erb
+++ b/source/rdio-favorites.applescript.js.erb
@@ -1,12 +1,13 @@
 // vim: filetype=javascript
 
 <%= File.read("./js/findRdioTab.js") %>
+<%= File.read("./js/rdioTab.js") %>
 
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
 function run(argv){
   var rdioTab = VimRdio.findRdioTab();
   var defineFunctions = <%= minify_javascript("all.js") %>;
-  rdioTab.execute({javascript: defineFunctions})
-  rdioTab.execute({javascript: "VimRdio.playFavorites()"});
+  rdioTab.executeJavascript(defineFunctions)
+  rdioTab.executeJavascript("VimRdio.playFavorites()");
 }

--- a/source/rdio-list-playlists.applescript.js.erb
+++ b/source/rdio-list-playlists.applescript.js.erb
@@ -1,6 +1,7 @@
 // vim: filetype=javascript
 
 <%= File.read("./js/findRdioTab.js") %>
+<%= File.read("./js/rdioTab.js") %>
 
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
@@ -9,8 +10,8 @@ function run(argv) {
 
   if( rdioTab !== undefined ){
     var defineFunctions = <%= minify_javascript("all.js") %>;
-    rdioTab.execute({javascript: defineFunctions})
-    var result = rdioTab.execute({javascript: "VimRdio.getPlaylistNames()"})
+    rdioTab.executeJavascript(defineFunctions);
+    var result = rdioTab.executeJavascript("VimRdio.getPlaylistNames()");
 
     // The return value gets printed to STDOUT.
     return result.join("\n");

--- a/source/rdio-next.applescript.js.erb
+++ b/source/rdio-next.applescript.js.erb
@@ -1,10 +1,11 @@
 // vim: filetype=javascript
 
 <%= File.read("./js/findRdioTab.js") %>
+<%= File.read("./js/rdioTab.js") %>
 
 function run(argv) {
   var rdioTab = VimRdio.findRdioTab();
   var defineFunctions = <%= minify_javascript("all.js") %>;
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: "VimRdio.next()"});
+  rdioTab.executeJavascript(defineFunctions)
+  rdioTab.executeJavascript("VimRdio.next()");
 }

--- a/source/rdio-play-pause.applescript.js.erb
+++ b/source/rdio-play-pause.applescript.js.erb
@@ -1,10 +1,11 @@
 // vim: filetype=javascript
 
 <%= File.read("./js/findRdioTab.js") %>
+<%= File.read("./js/rdioTab.js") %>
 
 function run(argv) {
   var rdioTab = VimRdio.findRdioTab();
   var defineFunctions = <%= minify_javascript("all.js") %>;
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({javascript: "VimRdio.playPause()"});
+  rdioTab.executeJavascript(defineFunctions);
+  rdioTab.executeJavascript("VimRdio.playPause()");
 }

--- a/source/rdio-play-specific-playlist.applescript.js.erb
+++ b/source/rdio-play-specific-playlist.applescript.js.erb
@@ -1,6 +1,7 @@
 // vim: filetype=javascript
 
 <%= File.read("./js/findRdioTab.js") %>
+<%= File.read("./js/rdioTab.js") %>
 
 // The "run" function is automatically run when the file is run, like "main" in
 // some other languages.
@@ -8,8 +9,8 @@ function run(argv){
   var rdioTab = VimRdio.findRdioTab();
   var playlistName = argv[0];
   var defineFunctions = <%= minify_javascript("all.js") %>;
-  rdioTab.execute({javascript: defineFunctions});
-  rdioTab.execute({
-    javascript: 'VimRdio.selectAndPlayPlaylist("' + playlistName + '")'
-  });
+  rdioTab.executeJavascript(defineFunctions);
+  rdioTab.executeJavascript(
+    'VimRdio.selectAndPlayPlaylist("' + playlistName + '")'
+  );
 }


### PR DESCRIPTION
As part of supporting >1 browser, add a compatibility layer for Safari/Chrome.

Safari and Chrome have different APIs to run Javascript in a specific tab.

Therefore, we now wrap the "raw" tab found via Applescript in a custom JS facade object to provide a standard API. The facade knows which application it's for (Safari or Chrome) and will run provided JS accordingly.